### PR TITLE
Removed Vulpes Rods from Ore Directory

### DIFF
--- a/scripts/AdvancedRocketry.zs
+++ b/scripts/AdvancedRocketry.zs
@@ -175,6 +175,11 @@ mods.jei.JEI.hide(<libvulpes:productrod:6>);
 mods.jei.JEI.hide(<libvulpes:productrod:7>);
 mods.jei.JEI.hide(<libvulpes:productboule:3>);
 
+	#Removing AR rods from ore directory to prevent JEI from placing them in crafting benches
+<ore:stickIridium>.remove(<libvulpes:productrod:10>);
+<ore:stickCopper>.remove(<libvulpes:productrod:4>);
+<ore:stickSteel>.remove(<libvulpes:productrod:6>);
+<ore:stickTitanium>.remove(<libvulpes:productrod:7>);
 
 	#hide nuggets
 mods.jei.JEI.hide(<libvulpes:productnugget:10>);


### PR DESCRIPTION
Corrects the following issue with recipies involving various rods

https://github.com/FTBTeam/FTB-Interactions/issues/816